### PR TITLE
暗号化の追加

### DIFF
--- a/manage.txt.gpg
+++ b/manage.txt.gpg
@@ -1,0 +1,1 @@
+Œ	PæiW‹ŒÿÒ?F	4‚s¦T?¿Ýß°zO¡¼×o{™•öë£§dÚxj ee÷9Ü5¯$Óñó®²›Õxcó]ž1òh

--- a/password_manager.sh
+++ b/password_manager.sh
@@ -5,7 +5,7 @@ function input() {
   read -p 'サービス名を入力してください：' service
   
   # 入力されたサービス名と同じ名前がすでにあれば取得
-  match=$(grep -Po '^.*?(?=:.*)' manage.txt | grep -x $service)
+  match=$(gpg -d --batch --quiet --passphrase=hoge manage.txt.gpg | grep -Po '^.*?(?=:.*)' | grep -x $service)
   
   if [ -z "$match" ]; then
     read -p 'ユーザー名を入力してください：' user
@@ -15,7 +15,13 @@ function input() {
   if [[ "$service" =~ .*:.* || "$user" =~ .*:.* || "$password" =~ .*:.* ]]; then
     echo ':を含む文字列は扱えません。'
   elif [ -z "$match" ]; then
+    gpg -do manage.txt --batch --quiet --yes --passphrase=hoge manage.txt.gpg
+    
     echo "$service:$user:$password" >> manage.txt
+   
+    gpg -c --batch --quiet --yes --passphrase=hoge manage.txt
+    rm manage.txt
+     
     echo 'パスワードの追加は成功しました。'
   else
     echo 'すでに登録されています。'
@@ -27,13 +33,13 @@ function output() {
   read -p 'サービス名を入力してください：' service
   
   # 一致したサービス名を取得
-  service_info=$(grep -Po '^.*?(?=:.*)' manage.txt | grep -x $service)
+  service_info=$(gpg -d --batch --quiet --passphrase=hoge manage.txt.gpg | grep -Po '^.*?(?=:.*)' | grep -x $service)
   
   if [ "$service_info" = "" ]; then
     echo 'そのサービスは登録されていません。'
   else
-    user_info=$(grep -Po "(?<=$service_info:).*?(?=:.*)" manage.txt)
-    password_info=$(grep -Po "(?<=$service_info:$user_info:).*" manage.txt)
+    user_info=$(gpg -d --batch --quiet --passphrase=hoge manage.txt.gpg | grep -Po "(?<=$service_info:).*?(?=:.*)")
+    password_info=$(gpg -d --batch --quiet --passphrase=hoge manage.txt.gpg | grep -Po "(?<=$service_info:$user_info:).*")
     
     echo "サービス名：$service_info"
     echo "ユーザー名：$user_info"


### PR DESCRIPTION
## やったこと
- GnuPGによるファイルの暗号化

## やらないこと
- なし

## できるようになること（ユーザー目線）
- パスワードが保存されているファイルの暗号化

## できなくなること（ユーザー目線）
- パスワードが保存されているファイルを直接確認する

## 動作確認
- パスワードを保存しているファイルが暗号化されている
- ファイルから情報を呼び出すときファイル自体は暗号化されたまま

## その他
- なし
